### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -520,7 +520,7 @@
 			<dependency>
 				<groupId>commons-collections</groupId>
 				<artifactId>commons-collections</artifactId>
-				<version>3.2.1</version>
+				<version>3.2.2</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-pool</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,13 +7,22 @@
 	<packaging>pom</packaging>
 	<version>0.1.0.BUILD-SNAPSHOT</version>
 	<name>Spring 4 Sandbox</name>
-	<description>Sample codes for demonstrating the new features of Spring 4</description>
+	<description>My sandbox for Spring 4 practice</description>
+	<parent>
+		<groupId>io.spring.platform</groupId>
+		<artifactId>platform-bom</artifactId>
+		<version>2.0.3.RELEASE</version>
+		<relativePath />
+	</parent>
 	<modules>
 		<module>groovy-dsl</module>
 		<module>generic-type-injection</module>
 		<module>meta-annotation</module>
 		<module>jdbc</module>
 		<module>jpa</module>
+		<module>jpa-audit</module>
+		<module>jpa-cache</module>
+		<module>hibernate-envers</module>
 		<module>hibernate4</module>
 		<module>hibernate5</module>
 		<module>data-jpa</module>
@@ -25,9 +34,8 @@
 		<module>data-keyvalue</module>
 		<module>data-redis</module>
 		<module>data-elasticsearch</module>
-		<module>jpa-audit</module>
-		<module>jpa-revision</module>
-		<module>jpa-cache</module>
+		<module>data-neo4j</module>
+		<module>data-envers</module>
 		<module>cache-concurrentmap</module>
 		<module>cache-ehcache</module>
 		<module>cache-gemfire</module>
@@ -48,29 +56,44 @@
 		<module>mvc-tiles3</module>
 		<module>mvc-thymeleaf</module>
 		<module>mvc-jsf2</module>
+		<module>mvc-freemarker</module>
 	</modules>
 	<properties>
-		<aspectj.version>1.8.4</aspectj.version>
+		<aspectj.version>1.8.8</aspectj.version>
 		<java.version>1.8</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<roo.version>1.2.3.RELEASE</roo.version>
 		<slf4j.version>1.7.7</slf4j.version>
-		<querydsl.version>3.6.3</querydsl.version>
-		<mongo-java-driver.version>2.12.2</mongo-java-driver.version>
-		<spring.version>4.2.0.RELEASE</spring.version>
-		<spring-batch.version>3.0.4.RELEASE</spring-batch.version>
-		<spring-webflow.version>2.4.1.RELEASE</spring-webflow.version>
-		<spring-security.version>4.0.2.RELEASE</spring-security.version>
-		<hibernate.version>4.3.11.Final</hibernate.version>
-		<hibernate5.version>5.0.0.CR4</hibernate5.version>
-		<hazelcast.version>3.2.3</hazelcast.version>
-		<infinispan.version>6.0.2.Final</infinispan.version>
-		<jackson.version>2.6.0</jackson.version>
-		<groovy.version>2.4.3</groovy.version>
-		<tiles.version>3.0.5</tiles.version>
+		<log4j.version>1.2.17</log4j.version>
 
-		<!-- Thymeleaf -->
-		<thymeleaf.version>2.1.4.RELEASE</thymeleaf.version>
+		<spring.version>4.2.5.RELEASE</spring.version>
+		<spring-batch.version>3.0.6.RELEASE</spring-batch.version>
+		<spring-webflow.version>2.4.2.RELEASE</spring-webflow.version>
+		<spring-security.version>4.0.4.RELEASE</spring-security.version>
+		<spring-data-releasetrain.version>Hopper-M1</spring-data-releasetrain.version>
+		<spring-data-neo4j.version>4.1.0.M1</spring-data-neo4j.version>
+		<mongo-java-driver.version>3.2.0</mongo-java-driver.version>
+		<neo4j.version>2.3.2</neo4j.version>
+		<neo4j-ogm.version>2.0.0-M02</neo4j-ogm.version>
+		<querydsl.version>4.0.7</querydsl.version>
+		<hibernate.version>4.3.11.Final</hibernate.version>
+		<hibernate5.version>5.1.0.Final</hibernate5.version>
+		<hibernate-validator.version>5.2.2.Final</hibernate-validator.version>
+		<hazelcast.version>3.5.4</hazelcast.version>
+		<infinispan.version>6.0.2.Final</infinispan.version>
+		<jackson.version>2.6.4</jackson.version>
+		<groovy.version>2.4.3</groovy.version>
+
+		<tiles.version>3.0.5</tiles.version>
+		<!-- <thymeleaf.version>3.0.0.BETA02</thymeleaf.version> -->
+		<freemarker.version>2.3.23</freemarker.version>
+
+		<!-- Test -->
+		<mockito.version>2.0.33-beta</mockito.version>
+		<geb.version>0.12.2</geb.version>
+		<spock.version>1.0-groovy-2.4</spock.version>
+		<selenium.version>2.46.0</selenium.version>
+		<htmlunit.version>2.18</htmlunit.version>
+		<jacoco.version>0.7.5.201505241946</jacoco.version>
 	</properties>
 	<repositories>
 		<repository>
@@ -117,60 +140,21 @@
 
 			<!-- Spring IO Platform BOM -->
 			<!-- <dependency> <groupId>io.spring.platform</groupId> <artifactId>platform-bom</artifactId> 
-				<version>1.1.2.RELEASE</version> <type>pom</type> <scope>import</scope> </dependency> -->
-
+				<version>2.0.2.RELEASE</version> <type>pom</type> <scope>import</scope> </dependency> -->
 
 			<!-- Spring BOM -->
-			<dependency>
-				<groupId>org.springframework</groupId>
-				<artifactId>spring-framework-bom</artifactId>
-				<version>${spring.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
+			<!-- <dependency> <groupId>org.springframework</groupId> <artifactId>spring-framework-bom</artifactId> 
+				<version>${spring.version}</version> <type>pom</type> <scope>import</scope> 
+				</dependency> -->
 
 			<!-- Spring Data -->
-			<dependency>
-				<groupId>org.springframework.data</groupId>
-				<artifactId>spring-data-releasetrain</artifactId>
-				<version>Gosling-M1</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
+			<!-- <dependency> <groupId>org.springframework.data</groupId> <artifactId>spring-data-releasetrain</artifactId> 
+				<version>Gosling-SR2A</version> <type>pom</type> <scope>import</scope> </dependency> -->
 
 			<!-- Spring security -->
-			<dependency>
-				<groupId>org.springframework.security</groupId>
-				<artifactId>spring-security-core</artifactId>
-				<version>${spring-security.version}</version>
-				<exclusions>
-					<exclusion>
-						<groupId>commons-logging</groupId>
-						<artifactId>commons-logging</artifactId>
-					</exclusion>
-				</exclusions>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.security</groupId>
-				<artifactId>spring-security-config</artifactId>
-				<version>${spring-security.version}</version>
-				<exclusions>
-					<exclusion>
-						<groupId>commons-logging</groupId>
-						<artifactId>commons-logging</artifactId>
-					</exclusion>
-				</exclusions>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.security</groupId>
-				<artifactId>spring-security-web</artifactId>
-				<version>${spring-security.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.security</groupId>
-				<artifactId>spring-security-taglibs</artifactId>
-				<version>${spring-security.version}</version>
-			</dependency>
+			<!-- <dependency> <groupId>org.springframework.security</groupId> <artifactId>spring-security-bom</artifactId> 
+				<version>${spring-security.version}</version> <type>pom</type> <scope>import</scope> 
+				</dependency> -->
 
 			<!--Spring batch -->
 			<dependency>
@@ -206,15 +190,17 @@
 
 			<dependency>
 				<groupId>com.fasterxml.jackson.datatype</groupId>
-				<artifactId>jackson-datatype-joda</artifactId>
+				<artifactId>jackson-datatype-java8</artifactId>
 				<version>${jackson.version}</version>
 			</dependency>
 
 			<dependency>
-				<groupId>com.jayway.jsonpath</groupId>
-				<artifactId>json-path</artifactId>
-				<version>2.0.0</version>
+				<groupId>com.fasterxml.jackson.datatype</groupId>
+				<artifactId>jackson-datatype-joda</artifactId>
+				<version>${jackson.version}</version>
 			</dependency>
+
+
 
 			<!--AspectJ -->
 			<dependency>
@@ -235,64 +221,6 @@
 				<version>2.4.3</version>
 			</dependency>
 
-			<!--java ee 7 facilities -->
-			<dependency>
-				<groupId>javax.servlet</groupId>
-				<artifactId>javax.servlet-api</artifactId>
-				<version>3.1.0</version>
-				<scope>provided</scope>
-			</dependency>
-
-
-			<!--Legacy JSP dependencies -->
-			<!--Tomcat includes jsp-api, el-api and a jasper el impl -->
-			<dependency>
-				<groupId>javax.servlet.jsp</groupId>
-				<artifactId>jsp-api</artifactId>
-				<version>2.2.1-b03</version>
-				<scope>provided</scope>
-			</dependency>
-			<dependency>
-				<groupId>javax.servlet.jsp.jstl</groupId>
-				<artifactId>jstl-api</artifactId>
-				<version>1.2</version>
-			</dependency>
-			<dependency>
-				<groupId>org.glassfish.web</groupId>
-				<artifactId>jstl-impl</artifactId>
-				<version>1.2</version>
-			</dependency>
-			<dependency>
-				<groupId>javax.el</groupId>
-				<artifactId>el-api</artifactId>
-				<version>2.2</version>
-				<scope>provided</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.glassfish.web</groupId>
-				<artifactId>el-impl</artifactId>
-				<version>2.2.1-b05</version>
-				<scope>provided</scope>
-			</dependency>
-
-			<!--JTA -->
-			<dependency>
-				<groupId>javax.transaction</groupId>
-				<artifactId>javax.transaction-api</artifactId>
-				<version>1.2</version>
-			</dependency>
-
-			<!-- java mail -->
-			<dependency>
-				<groupId>javax.mail</groupId>
-				<artifactId>mail</artifactId>
-				<version>1.4.1</version>
-			</dependency>
-			<dependency>
-				<groupId>javax.activation</groupId>
-				<artifactId>activation</artifactId>
-				<version>1.1.1</version>
-			</dependency>
 
 
 			<!--java persistence API 2.1 -->
@@ -336,14 +264,14 @@
 			<dependency>
 				<groupId>org.glassfish</groupId>
 				<artifactId>javax.faces</artifactId>
-				<version>2.2.11</version>
+				<version>2.2.13</version>
 			</dependency>
 
 			<!--bean validation -->
 			<dependency>
 				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-validator</artifactId>
-				<version>5.1.1.Final</version>
+				<version>${hibernate-validator.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>javax.validation</groupId>
@@ -413,7 +341,7 @@
 			<dependency>
 				<groupId>com.google.guava</groupId>
 				<artifactId>guava</artifactId>
-				<version>17.0</version>
+				<version>19.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.ehcache</groupId>
@@ -435,26 +363,26 @@
 
 			<!--QueryDSL -->
 			<dependency>
-				<groupId>com.mysema.querydsl</groupId>
+				<groupId>com.querydsl</groupId>
 				<artifactId>querydsl-apt</artifactId>
 				<version>${querydsl.version}</version>
 				<scope>provided</scope>
 			</dependency>
 
 			<dependency>
-				<groupId>com.mysema.querydsl</groupId>
+				<groupId>com.querydsl</groupId>
 				<artifactId>querydsl-collections</artifactId>
 				<version>${querydsl.version}</version>
 			</dependency>
 
 			<dependency>
-				<groupId>com.mysema.querydsl</groupId>
+				<groupId>com.querydsl</groupId>
 				<artifactId>querydsl-mongodb</artifactId>
 				<version>${querydsl.version}</version>
 			</dependency>
 
 			<dependency>
-				<groupId>com.mysema.querydsl</groupId>
+				<groupId>com.querydsl</groupId>
 				<artifactId>querydsl-jpa</artifactId>
 				<version>${querydsl.version}</version>
 			</dependency>
@@ -470,7 +398,7 @@
 			<dependency>
 				<groupId>log4j</groupId>
 				<artifactId>log4j</artifactId>
-				<version>1.2.17</version>
+				<version>${log4j.version}</version>
 				<scope>runtime</scope>
 			</dependency>
 			<dependency>
@@ -516,6 +444,12 @@
 					</exclusion>
 				</exclusions>
 			</dependency>
+			<dependency>
+				<groupId>xml-apis</groupId>
+				<artifactId>xml-apis</artifactId>
+				<version>1.4.01</version>
+				<scope>test</scope>
+			</dependency>
 
 			<dependency>
 				<groupId>commons-collections</groupId>
@@ -527,9 +461,6 @@
 				<artifactId>commons-pool</artifactId>
 				<version>1.5.6</version>
 			</dependency>
-
-
-
 
 			<dependency>
 				<groupId>commons-digester</groupId>
@@ -551,7 +482,7 @@
 			<dependency>
 				<groupId>commons-io</groupId>
 				<artifactId>commons-io</artifactId>
-				<version>2.1</version>
+				<version>2.4</version>
 			</dependency>
 
 			<!-- THYMELEAF -->
@@ -566,19 +497,121 @@
 				<version>${thymeleaf.version}</version>
 			</dependency>
 
+			<dependency>
+				<groupId>org.freemarker</groupId>
+				<artifactId>freemarker</artifactId>
+				<version>${freemarker.version}</version>
+			</dependency>
 
+			<dependency>
+				<groupId>org.apache.velocity</groupId>
+				<artifactId>velocity</artifactId>
+				<version>1.7</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.velocity</groupId>
+				<artifactId>velocity-tools</artifactId>
+				<version>2.0</version>
+			</dependency>
+
+			<!--webjars resources -->
+			<dependency>
+				<groupId>org.webjars</groupId>
+				<artifactId>bootstrap</artifactId>
+				<version>3.3.5</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.webjars</groupId>
+				<artifactId>jquery</artifactId>
+				<version>2.1.3</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.webjars</groupId>
+				<artifactId>font-awesome</artifactId>
+				<version>4.3.0-1</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.webjars</groupId>
+				<artifactId>bootstrap-material-design</artifactId>
+				<version>0.3.0</version>
+			</dependency>
 
 			<!--test -->
 			<dependency>
+				<groupId>org.springframework</groupId>
+				<artifactId>spring-test</artifactId>
+				<version>${spring.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.security</groupId>
+				<artifactId>spring-security-test</artifactId>
+				<version>${spring-security.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
 				<groupId>junit</groupId>
 				<artifactId>junit</artifactId>
-				<version>4.11</version>
+				<version>4.12</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.hamcrest</groupId>
+				<artifactId>hamcrest-all</artifactId>
+				<version>1.3</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.mockito</groupId>
+				<artifactId>mockito-core</artifactId>
+				<version>${mockito.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>com.jayway.jsonpath</groupId>
+				<artifactId>json-path</artifactId>
+				<version>2.0.0</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>
 				<groupId>com.h2database</groupId>
 				<artifactId>h2</artifactId>
-				<version>1.3.171</version>
+				<version>1.4.190</version>
+			</dependency>
+			<!-- <dependency> <groupId>org.seleniumhq.selenium</groupId> <artifactId>selenium-htmlunit-driver</artifactId> 
+				<version>${selenium.version}</version> <scope>test</scope> </dependency> 
+				<dependency> <groupId>net.sourceforge.htmlunit</groupId> <artifactId>htmlunit</artifactId> 
+				<version>${htmlunit.version}</version> <scope>test</scope> </dependency> 
+				<dependency> <groupId>org.spockframework</groupId> <artifactId>spock-core</artifactId> 
+				<version>${spock.version}</version> <scope>test</scope> </dependency> <dependency> 
+				<groupId>org.spockframework</groupId> <artifactId>spock-spring</artifactId> 
+				<version>${spock.version}</version> <scope>test</scope> </dependency> -->
+			<dependency>
+				<groupId>org.seleniumhq.selenium</groupId>
+				<artifactId>selenium-support</artifactId>
+				<version>${selenium.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.gebish</groupId>
+				<artifactId>geb-spock</artifactId>
+				<version>${geb.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.easytesting</groupId>
+				<artifactId>fest-assert-core</artifactId>
+				<version>2.0M10</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.easytesting</groupId>
+				<artifactId>fest-assert</artifactId>
+				<version>1.4</version>
+				<scope>test</scope>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -590,7 +623,7 @@
 					<version>1.0.9</version> <executions> <execution> <goals> <goal>process</goal> 
 					</goals> <configuration> <outputDirectory>target/generated-sources/java</outputDirectory> 
 					<processors> <processor>org.springframework.data.mongodb.repository.support.MongoAnnotationProcessor</processor> 
-					<processor>com.mysema.query.apt.jpa.JPAAnnotationProcessor</processor> </processors> 
+					<processor>com.querydsl.apt.jpa.JPAAnnotationProcessor</processor> </processors> 
 					</configuration> </execution> </executions> </plugin> -->
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
@@ -614,12 +647,14 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-war-plugin</artifactId>
 					<version>2.2</version>
-					<!-- <configuration> <webXml>target/web.xml</webXml> </configuration> -->
+					<configuration>
+						<failOnMissingWebXml>false</failOnMissingWebXml>
+					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>2.5.1</version>
+					<version>3.3</version>
 					<configuration>
 						<source>${java.version}</source>
 						<target>${java.version}</target>
@@ -657,7 +692,7 @@
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>aspectj-maven-plugin</artifactId>
-					<version>1.4</version>
+					<version>1.8</version>
 					<!-- NB: do not use 1.3 or 1.3.x due to MASPECTJ-90 and do not use 1.4 
 						due to declare parents issue -->
 					<dependencies>
@@ -738,7 +773,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-eclipse-plugin</artifactId>
-					<version>2.7</version>
+					<version>2.10</version>
 					<!-- Note 2.8 does not work with AspectJ aspect path -->
 					<configuration>
 						<downloadSources>true</downloadSources>
@@ -748,8 +783,7 @@
 							<buildCommand>
 								<name>org.eclipse.ajdt.core.ajbuilder</name>
 								<arguments>
-									<aspectPath>org.springframework.aspects,
-										org.springframework.data.mongodb.crossstore</aspectPath>
+									<aspectPath>org.springframework.aspects,org.springframework.data.mongodb.crossstore</aspectPath>
 								</arguments>
 							</buildCommand>
 							<buildCommand>
@@ -758,7 +792,6 @@
 						</additionalBuildcommands>
 						<additionalProjectnatures>
 							<projectnature>org.eclipse.ajdt.ui.ajnature</projectnature>
-							<!-- <projectnature>com.springsource.sts.roo.core.nature</projectnature> -->
 							<projectnature>org.springframework.ide.eclipse.core.springnature</projectnature>
 						</additionalProjectnatures>
 					</configuration>
@@ -778,9 +811,9 @@
 					<version>2.2</version>
 				</plugin>
 				<plugin>
-					<groupId>org.mortbay.jetty</groupId>
+					<groupId>org.eclipse.jetty</groupId>
 					<artifactId>jetty-maven-plugin</artifactId>
-					<version>8.1.4.v20120524</version>
+					<version>9.3.0.v20150612</version>
 					<configuration>
 						<webAppConfig>
 							<contextPath>/${project.name}</contextPath>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
